### PR TITLE
GKE version prefix, pin CNRM bundle

### DIFF
--- a/infrastructure/apps/prod/app1/app1_gke/main.tf
+++ b/infrastructure/apps/prod/app1/app1_gke/main.tf
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_container_engine_versions" "subnet_03" {
+data "google_container_engine_versions" "r1a_subnet_03" {
   project        = data.terraform_remote_state.app1_project.outputs.dev1_project_id
-  location       = var.subnet_03_region
+  location       = "${var.subnet_03_region}-a"
+  version_prefix = var.kubernetes_version
+}
+
+data "google_container_engine_versions" "r1b_subnet_03" {
+  project        = data.terraform_remote_state.app1_project.outputs.dev1_project_id
+  location       = "${var.subnet_03_region}-b"
   version_prefix = var.kubernetes_version
 }
 
@@ -23,7 +29,7 @@ module "create_gke_1_dev1_r1a_subnet_03" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app1_project.outputs.dev1_project_id
   name               = var.gke_dev1-r1a
-  kubernetes_version = data.google_container_engine_versions.subnet_03.latest_master_version
+  kubernetes_version = data.google_container_engine_versions.r1a_subnet_03.latest_master_version
   region             = var.subnet_03_region
   regional           = false
   zones              = ["${var.subnet_03_region}-a"]
@@ -73,7 +79,7 @@ module "create_gke_2_dev1_r1b_subnet_03" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app1_project.outputs.dev1_project_id
   name               = var.gke_dev1-r1b
-  kubernetes_version = data.google_container_engine_versions.subnet_03.latest_master_version
+  kubernetes_version = data.google_container_engine_versions.r1b_subnet_03.latest_master_version
   region             = var.subnet_03_region
   regional           = false
   zones              = ["${var.subnet_03_region}-b"]

--- a/infrastructure/apps/prod/app1/app1_gke/main.tf
+++ b/infrastructure/apps/prod/app1/app1_gke/main.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 data "google_container_engine_versions" "subnet_03" {
+  project        = data.terraform_remote_state.app1_project.outputs.dev1_project_id
   location       = var.subnet_03_region
   version_prefix = var.kubernetes_version
 }

--- a/infrastructure/apps/prod/app1/app1_gke/main.tf
+++ b/infrastructure/apps/prod/app1/app1_gke/main.tf
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "google_container_engine_versions" "subnet_03" {
+  location       = var.subnet_03_region
+  version_prefix = var.kubernetes_version
+}
+
 # gke-1-apps-r1a-prod - Create GKE zonal cluster in dev1 project using subnet-03 zone a
 module "create_gke_1_dev1_r1a_subnet_03" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app1_project.outputs.dev1_project_id
   name               = var.gke_dev1-r1a
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = data.google_container_engine_versions.subnet_03.latest_master_version
   region             = var.subnet_03_region
   regional           = false
   zones              = ["${var.subnet_03_region}-a"]
@@ -67,7 +72,7 @@ module "create_gke_2_dev1_r1b_subnet_03" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app1_project.outputs.dev1_project_id
   name               = var.gke_dev1-r1b
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = data.google_container_engine_versions.subnet_03.latest_master_version
   region             = var.subnet_03_region
   regional           = false
   zones              = ["${var.subnet_03_region}-b"]

--- a/infrastructure/apps/prod/app1/app1_gke/variables.tf
+++ b/infrastructure/apps/prod/app1/app1_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.7-gke.25" }
+variable "kubernetes_version" { default = "1.14.8" }
 variable "gke_dev1-r1a" { default = "gke-1-apps-r1a-prod" }
 variable "gke_dev1-r1b" { default = "gke-2-apps-r1b-prod" }
 variable "project_editor" {}

--- a/infrastructure/apps/prod/app2/app2_gke/main.tf
+++ b/infrastructure/apps/prod/app2/app2_gke/main.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 data "google_container_engine_versions" "subnet_04" {
+  project        = data.terraform_remote_state.app2_project.outputs.dev2_project_id
   location       = var.subnet_04_region
   version_prefix = var.kubernetes_version
 }

--- a/infrastructure/apps/prod/app2/app2_gke/main.tf
+++ b/infrastructure/apps/prod/app2/app2_gke/main.tf
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "google_container_engine_versions" "subnet_04" {
+  location       = var.subnet_04_region
+  version_prefix = var.kubernetes_version
+}
+
+
 # gke-3-apps-r2a-prod - Create GKE zonal cluster in dev2 project using subnet-04 zone a
 module "create_gke_3_dev2_r2a_subnet_04" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app2_project.outputs.dev2_project_id
   name               = var.gke_dev2-r2a
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = data.google_container_engine_versions.subnet_04.latest_master_version
   region             = var.subnet_04_region
   regional           = false
   zones              = ["${var.subnet_04_region}-a"]
@@ -67,7 +73,7 @@ module "create_gke_4_dev2_r2b_subnet_04" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app2_project.outputs.dev2_project_id
   name               = var.gke_dev2-r2b
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = data.google_container_engine_versions.subnet_04.latest_master_version
   region             = var.subnet_04_region
   regional           = false
   zones              = ["${var.subnet_04_region}-b"]

--- a/infrastructure/apps/prod/app2/app2_gke/main.tf
+++ b/infrastructure/apps/prod/app2/app2_gke/main.tf
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_container_engine_versions" "subnet_04" {
+data "google_container_engine_versions" "r2a_subnet_04" {
   project        = data.terraform_remote_state.app2_project.outputs.dev2_project_id
-  location       = var.subnet_04_region
+  location       = "${var.subnet_04_region}-a"
+  version_prefix = var.kubernetes_version
+}
+
+data "google_container_engine_versions" "r2b_subnet_04" {
+  project        = data.terraform_remote_state.app2_project.outputs.dev2_project_id
+  location       = "${var.subnet_04_region}-b"
   version_prefix = var.kubernetes_version
 }
 
@@ -24,7 +30,7 @@ module "create_gke_3_dev2_r2a_subnet_04" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app2_project.outputs.dev2_project_id
   name               = var.gke_dev2-r2a
-  kubernetes_version = data.google_container_engine_versions.subnet_04.latest_master_version
+  kubernetes_version = data.google_container_engine_versions.r2a_subnet_04.latest_master_version
   region             = var.subnet_04_region
   regional           = false
   zones              = ["${var.subnet_04_region}-a"]
@@ -74,7 +80,7 @@ module "create_gke_4_dev2_r2b_subnet_04" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.app2_project.outputs.dev2_project_id
   name               = var.gke_dev2-r2b
-  kubernetes_version = data.google_container_engine_versions.subnet_04.latest_master_version
+  kubernetes_version = data.google_container_engine_versions.r2b_subnet_04.latest_master_version
   region             = var.subnet_04_region
   regional           = false
   zones              = ["${var.subnet_04_region}-b"]

--- a/infrastructure/apps/prod/app2/app2_gke/variables.tf
+++ b/infrastructure/apps/prod/app2/app2_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.7-gke.25" }
+variable "kubernetes_version" { default = "1.14.8" }
 variable "gke_dev2-r2a" { default = "gke-3-apps-r2a-prod" }
 variable "gke_dev2-r2b" { default = "gke-4-apps-r2b-prod" }
 variable "project_editor" {}

--- a/infrastructure/ops/prod/istio_prep/main.tf
+++ b/infrastructure/ops/prod/istio_prep/main.tf
@@ -19,8 +19,7 @@ locals {
 wget -qO- https://github.com/istio/operator/archive/${var.istio_version}.tar.gz | tar -zxf - operator-${var.istio_version}/deploy
 gsutil -m rsync -r -d operator-${var.istio_version}/deploy gs://${var.tfadmin_proj}/ops/istio-operator-${var.istio_version}
 
-wget -qO- --header "Authorization: Bearer $(gcloud auth print-access-token)" \
-  https://us-central1-cnrm-eap.cloudfunctions.net/download/latest/infra/install-bundle-with-workload-identity.tar.gz | tar -zxvf - 
+wget -qO- https://storage.googleapis.com/asm-workshop/install-bundle-with-workload-identity.tar.gz | tar -zxvf - 
 gsutil -m rsync -r -d install-bundle gs://${var.tfadmin_proj}/ops/cnrm/install-bundle
   EOT
 

--- a/infrastructure/ops/prod/k8s_repo/config/cnrm-system/kustomization.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/cnrm-system/kustomization.yaml
@@ -13,5 +13,5 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: ClusterRole
-      name: cnrm-manager-role
+      name: cnrm-manager-cluster-role
     path: jsonpatch-cnrm-clusterrole.yaml

--- a/infrastructure/ops/prod/ops_gke/main.tf
+++ b/infrastructure/ops/prod/ops_gke/main.tf
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 data "google_container_engine_versions" "subnet_01" {
+  project        = data.terraform_remote_state.ops_project.outputs.ops_project_id
   location       = var.subnet_01_region
   version_prefix = var.kubernetes_version
 }
 
 data "google_container_engine_versions" "subnet_02" {
+  project        = data.terraform_remote_state.ops_project.outputs.ops_project_id
   location       = var.subnet_02_region
   version_prefix = var.kubernetes_version
 }

--- a/infrastructure/ops/prod/ops_gke/main.tf
+++ b/infrastructure/ops/prod/ops_gke/main.tf
@@ -12,12 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "google_container_engine_versions" "subnet_01" {
+  location       = var.subnet_01_region
+  version_prefix = var.kubernetes_version
+}
+
+data "google_container_engine_versions" "subnet_02" {
+  location       = var.subnet_02_region
+  version_prefix = var.kubernetes_version
+}
+
 # gke-asm-1-r1-prod - Create GKE regional cluster in ops-asm project using subnet-01
 module "create_gke_1_ops_asm_subnet_01" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.ops_project.outputs.ops_project_id
   name               = var.gke_asm_r1
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = data.google_container_engine_versions.subnet_01.latest_master_version
   region             = var.subnet_01_region
   zones              = ["${var.subnet_01_region}-a", "${var.subnet_01_region}-b", "${var.subnet_01_region}-c"]
   network_project_id = data.terraform_remote_state.shared_vpc.outputs.svpc_host_project_id
@@ -65,7 +75,7 @@ module "create_gke_2_ops_asm_subnet_02" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v5.1.1"
   project_id         = data.terraform_remote_state.ops_project.outputs.ops_project_id
   name               = var.gke_asm_r2
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = data.google_container_engine_versions.subnet_02.latest_master_version
   region             = var.subnet_02_region
   zones              = ["${var.subnet_02_region}-a", "${var.subnet_02_region}-b", "${var.subnet_02_region}-c"]
   network_project_id = data.terraform_remote_state.shared_vpc.outputs.svpc_host_project_id

--- a/infrastructure/ops/prod/ops_gke/variables.tf
+++ b/infrastructure/ops/prod/ops_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.7-gke.25" }
+variable "kubernetes_version" { default = "1.14.8" }
 variable "gke_asm_r1" { default = "gke-asm-1-r1-prod" }
 variable "gke_asm_r2" { default = "gke-asm-2-r2-prod" }
 variable "project_editor" {}


### PR DESCRIPTION
- Use data source to lookup GKE version by region with prefix
- Download CNRM installer from stable asm-workshop bucket.
- Fixed breaking CNRM manager ClusterRole resource name.