### PR TITLE
add hipster loadgen + fix stackdriver telemetry

### DIFF
--- a/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
@@ -87,7 +87,7 @@ spec:
               name: "istio-mixer-service-account"
               patches:
                 - path: metadata.annotations
-                  value: iam.gke.io/gcp-service-account: "istio-telemetry@smcghee-11932-01-ops.iam.gserviceaccount.com"
+                  value: iam.gke.io/gcp-service-account: "istio-telemetry@[[OPS_PROJECT]].iam.gserviceaccount.com"
             - kind: Service
               name: istio-telemetry
               patches:

--- a/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
@@ -83,6 +83,11 @@ spec:
         enabled: true
         k8s:
           overlays:
+            - kind: ServiceAccount
+              name: "istio-telemetry-sa"
+              patches:
+                - path: metadata.annotations
+                  value: kubernetes.io/psp: "istio-telemetry@smcghee-11932-01-ops.iam.gserviceaccount.com"
             - kind: Service
               name: istio-telemetry
               patches:

--- a/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
@@ -84,10 +84,10 @@ spec:
         k8s:
           overlays:
             - kind: ServiceAccount
-              name: "istio-telemetry-sa"
+              name: "istio-mixer-service-account"
               patches:
                 - path: metadata.annotations
-                  value: kubernetes.io/psp: "istio-telemetry@smcghee-11932-01-ops.iam.gserviceaccount.com"
+                  value: iam.gke.io/gcp-service-account:"istio-telemetry@smcghee-11932-01-ops.iam.gserviceaccount.com"
             - kind: Service
               name: istio-telemetry
               patches:

--- a/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
@@ -87,7 +87,7 @@ spec:
               name: "istio-mixer-service-account"
               patches:
                 - path: metadata.annotations
-                  value: iam.gke.io/gcp-service-account:"istio-telemetry@smcghee-11932-01-ops.iam.gserviceaccount.com"
+                  value: iam.gke.io/gcp-service-account: "istio-telemetry@smcghee-11932-01-ops.iam.gserviceaccount.com"
             - kind: Service
               name: istio-telemetry
               patches:

--- a/k8s_manifests/prod/app-cnrm/app-workload-identity-cnrm.yaml
+++ b/k8s_manifests/prod/app-cnrm/app-workload-identity-cnrm.yaml
@@ -17,6 +17,7 @@ spec:
         - serviceAccount:${PROJECT_ID}.svc.id.goog[currency/currency]
         - serviceAccount:${PROJECT_ID}.svc.id.goog[email/email]
         - serviceAccount:${PROJECT_ID}.svc.id.goog[frontend/frontend]
+        - serviceAccount:${PROJECT_ID}.svc.id.goog[loadgenerator/loadgenerator]
         - serviceAccount:${PROJECT_ID}.svc.id.goog[payment/payment]
         - serviceAccount:${PROJECT_ID}.svc.id.goog[product-catalog/product-catalog]
         - serviceAccount:${PROJECT_ID}.svc.id.goog[recommendation/recommendation]

--- a/k8s_manifests/prod/app/deployments/app-loadgenerator.yaml
+++ b/k8s_manifests/prod/app/deployments/app-loadgenerator.yaml
@@ -1,0 +1,46 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+spec:
+  selector:
+    matchLabels:
+      app: loadgenerator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: loadgenerator
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      terminationGracePeriodSeconds: 5
+      restartPolicy: Always
+      containers:
+      - name: main
+        image: loadgenerator
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
+        - name: USERS
+          value: "10"
+        resources:
+          requests:
+            cpu: 300m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/k8s_manifests/prod/app/deployments/app-loadgenerator.yaml
+++ b/k8s_manifests/prod/app/deployments/app-loadgenerator.yaml
@@ -15,6 +15,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadgenerator
+  namespace: loadgenerator
 spec:
   selector:
     matchLabels:
@@ -31,10 +32,10 @@ spec:
       restartPolicy: Always
       containers:
       - name: main
-        image: loadgenerator
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.3
         env:
         - name: FRONTEND_ADDR
-          value: "frontend:80"
+          value: "frontend.frontend:80"
         - name: USERS
           value: "10"
         resources:

--- a/k8s_manifests/prod/app/deployments/kustomization.yaml
+++ b/k8s_manifests/prod/app/deployments/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - app-currency-service.yaml
   - app-email-service.yaml
   - app-frontend.yaml
+  - app-loadgenerator.yaml
   - app-payment-service.yaml
   - app-product-catalog-service.yaml
   - app-recommendation-service.yaml

--- a/k8s_manifests/prod/app/namespaces/kustomization.yaml
+++ b/k8s_manifests/prod/app/namespaces/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - namespace-currency.yaml
   - namespace-email.yaml
   - namespace-frontend.yaml
+  - namespace-loadgenerator.yaml
   - namespace-payment.yaml
   - namespace-product-catalog.yaml
   - namespace-recommendation.yaml

--- a/k8s_manifests/prod/app/namespaces/namespace-loadgenerator.yaml
+++ b/k8s_manifests/prod/app/namespaces/namespace-loadgenerator.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loadgenerator
+  labels:
+    istio-injection: enabled

--- a/k8s_manifests/prod/app/podsecuritypolicies/kustomization.yaml
+++ b/k8s_manifests/prod/app/podsecuritypolicies/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - currency-psp.yaml
   - email-psp.yaml
   - frontend-psp.yaml
+  - loadgeneration-psp.yaml
   - payment-psp.yaml
   - product-catalog-psp.yaml
   - recommendation-psp.yaml

--- a/k8s_manifests/prod/app/podsecuritypolicies/kustomization.yaml
+++ b/k8s_manifests/prod/app/podsecuritypolicies/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - currency-psp.yaml
   - email-psp.yaml
   - frontend-psp.yaml
-  - loadgeneration-psp.yaml
+  - loadgenerator-psp.yaml
   - payment-psp.yaml
   - product-catalog-psp.yaml
   - recommendation-psp.yaml

--- a/k8s_manifests/prod/app/podsecuritypolicies/loadgenerator-psp.yaml
+++ b/k8s_manifests/prod/app/podsecuritypolicies/loadgenerator-psp.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: loadgenerator
+spec:
+  privileged: false # Prevents creation of privileged Pods
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - "*"

--- a/k8s_manifests/prod/app/rbac/kustomization.yaml
+++ b/k8s_manifests/prod/app/rbac/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - currency-rbac.yaml
   - email-rbac.yaml
   - frontend-rbac.yaml
+  - loadgenerator-rbac.yaml
   - payment-rbac.yaml
   - product-catalog-rbac.yaml
   - recommendation-rbac.yaml

--- a/k8s_manifests/prod/app/rbac/loadgenerator-rbac.yaml
+++ b/k8s_manifests/prod/app/rbac/loadgenerator-rbac.yaml
@@ -1,0 +1,37 @@
+# ClusterRole to use podsecuritypolicy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loadgenerator
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - loadgenerator
+---
+# Authorize all service accounts in namespace to use the podsecuritypolicy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loadgenerator
+  namespace: loadgenerator
+roleRef:
+  kind: ClusterRole
+  name: loadgenerator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccounts
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loadgenerator
+  namespace: loadgenerator
+  annotations:
+    iam.gke.io/gcp-service-account: microservices@${PROJECT_ID}.iam.gserviceaccount.com

--- a/scripts/setup-terraform-admin-project.sh
+++ b/scripts/setup-terraform-admin-project.sh
@@ -103,7 +103,8 @@ compute.googleapis.com \
 container.googleapis.com \
 serviceusage.googleapis.com \
 sourcerepo.googleapis.com \
-cloudbuild.googleapis.com 
+cloudbuild.googleapis.com \
+contextgraph.googleapis.com
 
 echo -e "\n${CYAN}Getting Terraform admin project cloudbuild service account...${NC}"
 export TF_CLOUDBUILD_SA=$(gcloud projects describe $TF_ADMIN --format='value(projectNumber)')@cloudbuild.gserviceaccount.com


### PR DESCRIPTION
uses hipster loadgen now.
telemetry -> stackdriver now works (was a workload identity issue)

NOTE:  there is currently a placeholder value [[OPS_PROJECT]] in :
.../ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml

I'm hoping someone can suggest a better way around this?