### PR TITLE
update CNRM manifests to support v1beta1 release

### DIFF
--- a/infrastructure/ops/prod/k8s_repo/build_repo.sh
+++ b/infrastructure/ops/prod/k8s_repo/build_repo.sh
@@ -27,6 +27,11 @@ echo $(ls -d tmp/*/) | xargs -n 1 cp config/jsonpatch-istio-operator-clusterrole
 # Copy downloaded cnrm controller to every cluster and replace project ID.
 echo $(ls -d tmp/*/) | xargs -n 1 cp -r config/cnrm-system/
 gsutil -m cp -r gs://${tfadmin_proj}/ops/cnrm/install-bundle .
+
+# Patch CNRM CRDs to support IAMCustomRole references until #78 is fixed.
+#  https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/78
+sed -i '/pattern: \^roles/d' install-bundle/crds.yaml
+
 echo $(ls -d tmp/*/cnrm-system) | xargs -n 1 cp -r install-bundle
 rm -Rf install-bundle
 

--- a/infrastructure/ops/prod/k8s_repo/config/cnrm-system/cnrm-psp.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/cnrm-system/cnrm-psp.yaml
@@ -14,3 +14,37 @@ spec:
     rule: RunAsAny
   volumes:
     - "*"
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cnrm-webhook-manager
+spec:
+  privileged: false # Prevents creation of privileged Pods
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - "*"
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cnrm-resource-stats-recorder
+spec:
+  privileged: false # Prevents creation of privileged Pods
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - "*"

--- a/infrastructure/ops/prod/k8s_repo/config/cnrm-system/jsonpatch-cnrm-recorder-role.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/cnrm-system/jsonpatch-cnrm-recorder-role.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: "/rules/-"
+  value:
+    apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - cnrm-resource-stats-recorder
+    verbs:
+      - use

--- a/infrastructure/ops/prod/k8s_repo/config/cnrm-system/jsonpatch-cnrm-webhook-role.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/cnrm-system/jsonpatch-cnrm-webhook-role.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: "/rules/-"
+  value:
+    apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - cnrm-webhook-manager
+    verbs:
+      - use

--- a/infrastructure/ops/prod/k8s_repo/config/cnrm-system/kustomization.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/cnrm-system/kustomization.yaml
@@ -15,3 +15,15 @@ patchesJson6902:
       kind: ClusterRole
       name: cnrm-manager-cluster-role
     path: jsonpatch-cnrm-clusterrole.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: cnrm-recorder-role
+    path: jsonpatch-cnrm-recorder-role.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: cnrm-webhook-role
+    path: jsonpatch-cnrm-webhook-role.yaml

--- a/k8s_manifests/prod/app-cnrm/app-gcp-service-account-cnrm.yaml
+++ b/k8s_manifests/prod/app-cnrm/app-gcp-service-account-cnrm.yaml
@@ -16,7 +16,6 @@ spec:
   role: roles/logging.logWriter
   resourceRef:
     kind: Project
-    name: ${PROJECT_ID}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -28,7 +27,6 @@ spec:
   role: roles/monitoring.metricWriter
   resourceRef:
     kind: Project
-    name: ${PROJECT_ID}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -40,7 +38,6 @@ spec:
   role: roles/monitoring.viewer
   resourceRef:
     kind: Project
-    name: ${PROJECT_ID}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -52,7 +49,6 @@ spec:
   role: roles/clouddebugger.agent
   resourceRef:
     kind: Project
-    name: ${PROJECT_ID}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -64,7 +60,6 @@ spec:
   role: roles/cloudprofiler.agent
   resourceRef:
     kind: Project
-    name: ${PROJECT_ID}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
@@ -76,4 +71,3 @@ spec:
   role: roles/cloudtrace.agent
   resourceRef:
     kind: Project
-    name: ${PROJECT_ID}


### PR DESCRIPTION
- Patch CNRM install bundle to support referencing custom IAM roles.
- Add PodSecurityPolicy for CNRM webhook and stats recorder components
- Remove project ID name field from IAMPolicyMember resourceRef. 
