### PR TITLE
changed gke version 1.14.8 to 1.14

### DIFF
--- a/infrastructure/apps/prod/app1/app1_gke/variables.tf
+++ b/infrastructure/apps/prod/app1/app1_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.8" }
+variable "kubernetes_version" { default = "1.14" }
 variable "gke_dev1-r1a" { default = "gke-1-apps-r1a-prod" }
 variable "gke_dev1-r1b" { default = "gke-2-apps-r1b-prod" }
 variable "project_editor" {}

--- a/infrastructure/apps/prod/app2/app2_gke/variables.tf
+++ b/infrastructure/apps/prod/app2/app2_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.8" }
+variable "kubernetes_version" { default = "1.14" }
 variable "gke_dev2-r2a" { default = "gke-3-apps-r2a-prod" }
 variable "gke_dev2-r2b" { default = "gke-4-apps-r2b-prod" }
 variable "project_editor" {}

--- a/infrastructure/apps/prod/app3/app3_gke/variables.tf
+++ b/infrastructure/apps/prod/app3/app3_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.8" }
+variable "kubernetes_version" { default = "1.14" }
 variable "gke_dev3-r3b" { default = "gke-5-apps-r3b-prod" }
 variable "gke_dev3-r3c" { default = "gke-6-apps-r3c-prod" }
 variable "project_editor" {}

--- a/infrastructure/ops/prod/ops_gke/variables.tf
+++ b/infrastructure/ops/prod/ops_gke/variables.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "kubernetes_version" { default = "1.14.8" }
+variable "kubernetes_version" { default = "1.14" }
 variable "gke_asm_r1" { default = "gke-asm-1-r1-prod" }
 variable "gke_asm_r2" { default = "gke-asm-2-r2-prod" }
 variable "gke_asm_r3" { default = "gke-asm-3-r3-prod" }


### PR DESCRIPTION
1.14.8 no longer available

```  22: resource "google_container_cluster" "primary" {
  on .terraform/modules/create_gke_3_ops_asm_subnet_06/modules/beta-public-cluster/cluster.tf line 22, in resource "google_container_cluster" "primary":

Error: googleapi: Error 400: No valid versions with the prefix "1.14.8" found., badRequest

```

This will need to change for master as well.