### PR TITLE
Fix argument parsing of --set-up-for-admin

### DIFF
--- a/scripts/bootstrap_workshop.sh
+++ b/scripts/bootstrap_workshop.sh
@@ -45,8 +45,7 @@ BILLING_ID=
 
 while [ "$1" != "" ]; do
     case $1 in
-        --set-up-for-admin | -sufa )  shift
-                                      SETUP_ADMIN=true
+        --set-up-for-admin | -sufa )  SETUP_ADMIN=true # don't shift because it's a boolean flag
                                       ;;
         --org-name | -on )            shift
                                       ORG_NAME=$1


### PR DESCRIPTION
Every other argument is followed by a value, but this one is boolean, so shift'ing twice breaks subsequent args. I think this only strikes when `--set-up-for-admin` isn't the last argument, but I was having trouble with that, too.