### PR TITLE
[WIP] Istio 1.5, OnlineBoutique 0.2.0

### DIFF
--- a/infrastructure/ops/prod/istio_prep/variables.tf
+++ b/infrastructure/ops/prod/istio_prep/variables.tf
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # Istio
-variable "istio_version" { default = "1.4.3" }
+variable "istio_version" { default = "1.5.4" }

--- a/infrastructure/ops/prod/k8s_repo/build_repo.sh
+++ b/infrastructure/ops/prod/k8s_repo/build_repo.sh
@@ -73,10 +73,8 @@ done
 SRC="config/istio-controlplane/istio-replicated-controlplane.yaml"
 DEST="tmp/${ops_gke_1_name}/istio-controlplane/$(basename $SRC)"
 sed \
-  -e "s/POLICY_ILB_IP/${ops_gke_1_policy_ilb?env not set}/g" \
-  -e "s/TELEMETRY_ILB_IP/${ops_gke_1_telemetry_ilb?env not set}/g" \
   -e "s/PILOT_ILB_IP/${ops_gke_1_pilot_ilb?env not set}/g" \
-  -e "s/OPS_PROJECT/${ops_project_id}/g" \
+  -e "s/CLUSTER_NAME/${ops_gke_1_name}/g" \
   $SRC > $DEST
 
 # Update kustomization
@@ -86,10 +84,8 @@ sed \
 SRC="config/istio-controlplane/istio-replicated-controlplane.yaml"
 DEST="tmp/${ops_gke_2_name}/istio-controlplane/$(basename $SRC)"
 sed \
-  -e "s/POLICY_ILB_IP/${ops_gke_2_policy_ilb?env not set}/g" \
-  -e "s/TELEMETRY_ILB_IP/${ops_gke_2_telemetry_ilb?env not set}/g" \
   -e "s/PILOT_ILB_IP/${ops_gke_2_pilot_ilb?env not set}/g" \
-  -e "s/OPS_PROJECT/${ops_project_id}/g" \
+  -e "s/CLUSTER_NAME/${ops_gke_2_name}/g" \
   $SRC > $DEST
 
 # Update kustomization
@@ -100,11 +96,10 @@ for cluster in ${dev1_gke_1_name} ${dev1_gke_2_name}; do
   SRC="config/istio-controlplane/istio-shared-controlplane.yaml"
   DEST="tmp/$cluster/istio-controlplane/$(basename $SRC)"
   sed \
-    -e "s/POLICY_ILB_IP/${ops_gke_1_policy_ilb}/g" \
-    -e "s/TELEMETRY_ILB_IP/${ops_gke_1_telemetry_ilb}/g" \
+    -e "s/CLUSTER_NAME/${cluster}/g" \
     -e "s/PILOT_ILB_IP/${ops_gke_1_pilot_ilb}/g" \
     $SRC > $DEST
-  
+
   # Update kustomization
   (cd $(dirname $DEST) && kustomize edit add resource $(basename $DEST))
 done
@@ -114,11 +109,10 @@ for cluster in ${dev2_gke_3_name} ${dev2_gke_4_name}; do
   SRC="config/istio-controlplane/istio-shared-controlplane.yaml"
   DEST="tmp/$cluster/istio-controlplane/$(basename $SRC)"
   sed \
-    -e "s/POLICY_ILB_IP/${ops_gke_2_policy_ilb}/g" \
-    -e "s/TELEMETRY_ILB_IP/${ops_gke_2_telemetry_ilb}/g" \
+    -e "s/CLUSTER_NAME/${cluster}/g" \
     -e "s/PILOT_ILB_IP/${ops_gke_2_pilot_ilb}/g" \
     $SRC > $DEST
-  
+
   # Update kustomization
   (cd $(dirname $DEST) && kustomize edit add resource $(basename $DEST))
 done

--- a/infrastructure/ops/prod/k8s_repo/build_repo.sh
+++ b/infrastructure/ops/prod/k8s_repo/build_repo.sh
@@ -91,7 +91,7 @@ sed \
 # Update kustomization
 (cd $(dirname $DEST) && kustomize edit add resource $(basename $DEST))
 
-# Patch dev 1 clusters 1 and 2 with ILB IPs from ops 1.
+# Patch dev 1 clusters 1 and 2 with ILB IP from ops 1.
 for cluster in ${dev1_gke_1_name} ${dev1_gke_2_name}; do
   SRC="config/istio-controlplane/istio-shared-controlplane.yaml"
   DEST="tmp/$cluster/istio-controlplane/$(basename $SRC)"
@@ -104,7 +104,7 @@ for cluster in ${dev1_gke_1_name} ${dev1_gke_2_name}; do
   (cd $(dirname $DEST) && kustomize edit add resource $(basename $DEST))
 done
 
-# Patch dev 2 clusters 3 and 4 with ILB IPs from ops 2.
+# Patch dev 2 clusters 3 and 4 with ILB IP from ops 2.
 for cluster in ${dev2_gke_3_name} ${dev2_gke_4_name}; do
   SRC="config/istio-controlplane/istio-shared-controlplane.yaml"
   DEST="tmp/$cluster/istio-controlplane/$(basename $SRC)"

--- a/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-replicated-controlplane.yaml
@@ -1,179 +1,753 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
-metadata:
-  namespace: istio-operator
-  name: replicated-istiocontrolplane
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
 spec:
-  # Docs: https://istio.io/docs/reference/config/istio.operator.v1alpha12.pb/
-  autoInjection:
-    components:
-      injector:
-        enabled: true
-    enabled: true
-  cni:
-    components:
-      namespace: kube-system
-      cni:
-        enabled: true
-    enabled: true
-  configManagement:
-    components:
-      galley:
-        enabled: true
-    enabled: true
-  coreDNS:
-    components:
-      coreDNS:
-        enabled: true
-    enabled: true
-  gateways:
-    components:
-      egressGateway:
-        enabled: true
-        k8s:
-          env:
-            - name: ISTIO_META_REQUESTED_NETWORK_VIEW
-              value: external
-      ingressGateway:
-        enabled: true
-        k8s:
-          overlays:
-            - kind: Service
-              name: istio-ingressgateway
-              patches:
-                # Add annotation to service to use NEG and AutoNEG
-                # Full metadata replacement is a workaround for: https://github.com/istio/istio/issues/19463
-                - path: metadata
-                  value:
-                    name: istio-ingressgateway
-                    namespace: istio-system
-                    labels:
-                      app: istio-ingressgateway
-                      istio: ingressgateway
-                      release: istio
-                    annotations:
-                      cloud.google.com/neg: '{"exposed_ports": {"80":{}}}'
-                      anthos.cft.dev/autoneg: '{"name":"istio-ingressgateway", "max_rate_per_endpoint":100}'
-                # Change type to ClusterIP to remove external IP
-                - path: spec.type
-                  value: ClusterIP
-                # Clear external traffic policy for NEG support.
-                - path: spec.externalTrafficPolicy
-                  value: ""
-    enabled: true
-  policy:
-    components:
-      policy:
-        enabled: true
-        k8s:
-          overlays:
-            - kind: Service
-              name: istio-policy
-              patches:
-                - path: metadata.annotations
-                  value:
-                    cloud.google.com/load-balancer-type: "Internal"
-                - path: spec.type
-                  value: LoadBalancer
-                - path: spec.loadBalancerIP
-                  value: POLICY_ILB_IP
-    enabled: true
-  security:
-    components:
-      certManager:
-        enabled: false
-      citadel:
-        enabled: true
-      nodeAgent:
-        enabled: false
-    enabled: true
-  telemetry:
-    components:
-      telemetry:
-        enabled: true
-        k8s:
-          overlays:
-            - kind: ServiceAccount
-              name: "istio-mixer-service-account"
-              patches:
-                - path: metadata.annotations
-                  value: 
-                    iam.gke.io/gcp-service-account: "istio-telemetry@OPS_PROJECT.iam.gserviceaccount.com"
-            - kind: Service
-              name: istio-telemetry
-              patches:
-                - path: metadata.annotations
-                  value:
-                    cloud.google.com/load-balancer-type: "Internal"
-                - path: spec.type
-                  value: LoadBalancer
-                - path: spec.loadBalancerIP
-                  value: TELEMETRY_ILB_IP
-    enabled: true
-  trafficManagement:
-    enabled: true
-    components:
-      pilot:
-        enabled: true
-        k8s:
-          env:
-            - name: PILOT_ENABLE_FALLTHROUGH_ROUTE
-              value: "1"
-          overlays:
-            - kind: Service
-              name: istio-pilot
-              patches:
-                - path: metadata.annotations
-                  value:
-                    cloud.google.com/load-balancer-type: "Internal"
-                - path: spec.type
-                  value: LoadBalancer
-                - path: spec.loadBalancerIP
-                  value: PILOT_ILB_IP
-  values:
-    global:
-      controlPlaneSecurityEnabled: true
-      meshExpansion:
-        enabled: true
-      multiCluster:
-        enabled: true
-      podDNSSearchNamespaces:
-        - global
-        - '{{ valueOrDefault .DeploymentMeta.Namespace "default" }}.global'
+  addonComponents:
     grafana:
       enabled: true
-    kiali:
-      createDemoSecret: true
-      dashboard:
-        grafanaURL: http://grafana:3000
+      k8s:
+        replicaCount: 1
+    istiocoredns:
       enabled: true
+    kiali:
+      enabled: true
+      k8s:
+        replicaCount: 1
     prometheus:
       enabled: true
-    security:
-      selfSigned: false
-    sidecarInjectorWebhook:
-      rewriteAppHTTPProbe: true
+      k8s:
+        replicaCount: 1
     tracing:
       enabled: true
+  components:
+    base:
+      enabled: true
+    citadel:
+      enabled: false
+      k8s:
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
     cni:
-      cniBinDir: /home/kubernetes/bin
+      enabled: true
+    egressGateways:
+    - enabled: true
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-ingressgateway
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+      name: istio-egressgateway
+    galley:
+      enabled: false
+      k8s:
+        replicaCount: 1
+        resources:
+          requests:
+            cpu: 100m
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    ingressGateways:
+    - name: istio-ilbgateway
+      enabled: true
+      k8s:
+        serviceAnnotations:
+          cloud.google.com/load-balancer-type: "internal"
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-ilbgateway
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        service:
+          ports:
+          - name: grpc-pilot-mtls
+            port: 15011
+          - name: grpc-pilot
+            port: 15010
+          - name: tcp-citadel-grpc-tls
+            port: 8060
+            targetPort: 8060
+          - name: tcp-dns
+            port: 5353
+          - name: http
+            port: 80
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+        overlays:
+          - kind: HorizontalPodAutoscaler
+            name: istio-ilbgateway
+            patches:
+              - path: metadata.labels.app
+                value: istio-ilbgateway
+              - path: metadata.labels.istio
+                value: ilbgateway
+              - path: spec.scaleTargetRef.name
+                value: istio-ilbgateway
+          - kind: Deployment
+            name: istio-ilbgateway
+            patches:
+              - path: metadata.labels.app
+                value: istio-ilbgateway
+              - path: metadata.labels.istio
+                value: ilbgateway
+              - path: spec.selector.matchLabels.app
+                value: istio-ilbgateway
+              - path: spec.selector.matchLabels.istio
+                value: ilbgateway
+              - path: spec.template.metadata.labels.app
+                value: istio-ilbgateway
+              - path: spec.template.metadata.labels.istio
+                value: ilbgateway
+          - kind: Service
+            name: istio-ilbgateway
+            patches:
+              - path: metadata.labels.app
+                value: istio-ilbgateway
+              - path: metadata.labels.istio
+                value: ilbgateway
+              - path: spec.selector.app
+                value: istio-ilbgateway
+              - path: spec.selector.istio
+                value: ilbgateway
+    - name: istio-ingressgateway
+      enabled: true
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-ingressgateway
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    nodeAgent:
+      enabled: false
+    pilot:
+      enabled: true
+      k8s:
+        overlays:
+          - kind: Service
+            name: istio-pilot
+            patches:
+              - path: metadata.annotations
+                value:
+                  cloud.google.com/load-balancer-type: "Internal"
+              - path: spec.type
+                value: LoadBalancer
+              - path: spec.loadBalancerIP
+                value: PILOT_ILB_IP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2048Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    policy:
+      enabled: false
+      k8s:
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-policy
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    sidecarInjector:
+      enabled: false
+      k8s:
+        replicaCount: 1
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    telemetry:
+      enabled: false
+      k8s:
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: GOMAXPROCS
+          value: "6"
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-telemetry
+        replicaCount: 1
+        resources:
+          limits:
+            cpu: 4800m
+            memory: 4G
+          requests:
+            cpu: 1000m
+            memory: 1G
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+  hub: docker.io/istio
+  tag: 1.5.4
+  values:
+    cni:
       excludeNamespaces:
-        - istio-system
-        - kube-system
-  unvalidatedValues:
-    cni:
+       - istio-system
+       - kube-system
       logLevel: info
+    clusterResources: true
+    galley:
+      enableAnalysis: false
+      image: galley
+    gateways:
+      istio-egressgateway:
+        autoscaleEnabled: true
+        env:
+          ISTIO_META_ROUTER_MODE: sni-dnat
+        ports:
+        - name: http2
+          port: 80
+        - name: https
+          port: 443
+        - name: tls
+          port: 15443
+          targetPort: 15443
+        secretVolumes:
+        - mountPath: /etc/istio/egressgateway-certs
+          name: egressgateway-certs
+          secretName: istio-egressgateway-certs
+        - mountPath: /etc/istio/egressgateway-ca-certs
+          name: egressgateway-ca-certs
+          secretName: istio-egressgateway-ca-certs
+        type: ClusterIP
+      istio-ingressgateway:
+        applicationPorts: ""
+        autoscaleEnabled: true
+        debug: info
+        domain: ""
+        env:
+          ISTIO_META_ROUTER_MODE: sni-dnat
+        meshExpansionPorts:
+        - name: tcp-pilot-grpc-tls
+          port: 15011
+          targetPort: 15011
+        - name: tcp-citadel-grpc-tls
+          port: 8060
+          targetPort: 8060
+        - name: tcp-dns-tls
+          port: 853
+          targetPort: 853
+        ports:
+        - name: status-port
+          port: 15020
+          targetPort: 15020
+        - name: http2
+          port: 80
+          targetPort: 80
+        - name: https
+          port: 443
+        - name: kiali
+          port: 15029
+          targetPort: 15029
+        - name: prometheus
+          port: 15030
+          targetPort: 15030
+        - name: grafana
+          port: 15031
+          targetPort: 15031
+        - name: tracing
+          port: 15032
+          targetPort: 15032
+        - name: tls
+          port: 15443
+          targetPort: 15443
+        sds:
+          enabled: false
+          image: node-agent-k8s
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        secretVolumes:
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          secretName: istio-ingressgateway-certs
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          secretName: istio-ingressgateway-ca-certs
+        type: LoadBalancer
+        zvpn:
+          enabled: false
+          suffix: global
+    global:
+      arch:
+        amd64: 2
+        ppc64le: 2
+        s390x: 2
+      certificates: []
+      configValidation: true
+      controlPlaneSecurityEnabled: true
+      defaultNodeSelector: {}
+      defaultPodDisruptionBudget:
+        enabled: true
+      defaultResources:
+        requests:
+          cpu: 10m
+      disablePolicyChecks: true
+      enableHelmTest: false
+      enableTracing: true
+      imagePullPolicy: IfNotPresent
+      imagePullSecrets: []
+      istioNamespace: istio-system
+      istiod:
+        enabled: true
+      jwtPolicy: third-party-jwt
+      k8sIngress:
+        enableHttps: false
+        enabled: false
+        gatewayName: ingressgateway
+      localityLbSetting:
+        enabled: true
+      logAsJson: false
+      logging:
+        level: default:info
+      meshExpansion:
+        enabled: true
+        useILB: false
+      meshNetworks: {}
+      mountMtlsCerts: false
+      mtls:
+        auto: true
+        enabled: false
+      multiCluster:
+        enabled: true
+        clusterName: CLUSTER_NAME
+      network: ""
+      omitSidecarInjectorConfigMap: false
+      oneNamespace: false
+      operatorManageWebhooks: false
+      outboundTrafficPolicy:
+        mode: ALLOW_ANY
+      pilotCertProvider: istiod
+      podDNSSearchNamespaces:
+        - global
+        - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"
+      policyCheckFailOpen: false
+      priorityClassName: ""
+      proxy:
+        accessLogEncoding: TEXT
+        accessLogFile: "/dev/stdout"
+        accessLogFormat: ""
+        autoInject: enabled
+        clusterDomain: cluster.local
+        componentLogLevel: misc:error
+        concurrency: 2
+        dnsRefreshRate: 300s
+        enableCoreDump: false
+        envoyAccessLogService:
+          enabled: false
+        envoyMetricsService:
+          enabled: false
+          tcpKeepalive:
+            interval: 10s
+            probes: 3
+            time: 10s
+          tlsSettings:
+            mode: DISABLE
+            subjectAltNames: []
+        envoyStatsd:
+          enabled: false
+        excludeIPRanges: ""
+        excludeInboundPorts: ""
+        excludeOutboundPorts: ""
+        image: proxyv2
+        includeIPRanges: '*'
+        includeInboundPorts: '*'
+        kubevirtInterfaces: ""
+        logLevel: warning
+        privileged: false
+        protocolDetectionTimeout: 100ms
+        readinessFailureThreshold: 30
+        readinessInitialDelaySeconds: 1
+        readinessPeriodSeconds: 2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        statusPort: 15020
+        tracer: zipkin
+      proxy_init:
+        image: proxyv2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      sds:
+        enabled: false
+        token:
+          aud: istio-ca
+        udsPath: ""
+      sts:
+        servicePort: 0
+      tracer:
+        datadog:
+          address: $(HOST_IP):8126
+        lightstep:
+          accessToken: ""
+          address: ""
+          cacertPath: ""
+          secure: true
+        stackdriver:
+          debug: false
+          maxNumberOfAnnotations: 200
+          maxNumberOfAttributes: 200
+          maxNumberOfMessageEvents: 200
+        zipkin:
+          address: ""
+      trustDomain: cluster.local
+      useMCP: false
+    grafana:
+      accessMode: ReadWriteMany
+      contextPath: /grafana
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+          - disableDeletion: false
+            folder: istio
+            name: istio
+            options:
+              path: /var/lib/grafana/dashboards/istio
+            orgId: 1
+            type: file
+      datasources:
+        datasources.yaml:
+          apiVersion: 1
+      env: {}
+      envSecrets: {}
+      image:
+        repository: grafana/grafana
+        tag: 6.5.2
+      ingress:
+        enabled: false
+        hosts:
+        - grafana.local
+      nodeSelector: {}
+      persist: false
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      security:
+        enabled: false
+        passphraseKey: passphrase
+        secretName: grafana
+        usernameKey: username
+      service:
+        annotations: {}
+        externalPort: 3000
+        name: http
+        type: ClusterIP
+      storageClassName: ""
+      tolerations: []
+    istiocoredns:
+      coreDNSImage: coredns/coredns
+      coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
+      coreDNSTag: 1.6.2
+    kiali:
+      contextPath: /kiali
+      createDemoSecret: true
+      dashboard:
+        grafanaInClusterURL: http://grafana:3000
+        jaegerInClusterURL: http://tracing/jaeger
+        passphraseKey: passphrase
+        secretName: kiali
+        usernameKey: username
+        viewOnlyMode: false
+      hub: quay.io/kiali
+      ingress:
+        enabled: false
+        hosts:
+        - kiali.local
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      security:
+        cert_file: /kiali-cert/cert-chain.pem
+        enabled: false
+        private_key_file: /kiali-cert/key.pem
+      tag: v1.14
+    mixer:
+      adapters:
+        kubernetesenv:
+          enabled: true
+        prometheus:
+          enabled: true
+          metricsExpiryDuration: 10m
+        stackdriver:
+          auth:
+            apiKey: ""
+            appCredentials: false
+            serviceAccountPath: ""
+          enabled: false
+          tracer:
+            enabled: false
+            sampleProbability: 1
+        stdio:
+          enabled: false
+          outputAsJson: false
+        useAdapterCRDs: false
+      policy:
+        adapters:
+          kubernetesenv:
+            enabled: true
+          useAdapterCRDs: false
+        autoscaleEnabled: true
+        image: mixer
+        sessionAffinityEnabled: false
+      telemetry:
+        autoscaleEnabled: true
+        env:
+          GOMAXPROCS: "6"
+        image: mixer
+        loadshedding:
+          latencyThreshold: 100ms
+          mode: enforce
+        nodeSelector: {}
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
+        replicaCount: 1
+        reportBatchMaxEntries: 100
+        reportBatchMaxTime: 1s
+        sessionAffinityEnabled: false
+        tolerations: []
+    nodeagent:
+      image: node-agent-k8s
+    pilot:
+      appNamespaces: []
+      autoscaleEnabled: true
+      autoscaleMax: 5
+      autoscaleMin: 1
+      configMap: true
+      configNamespace: istio-config
+      cpu:
+        targetAverageUtilization: 80
+      enableProtocolSniffingForInbound: false
+      enableProtocolSniffingForOutbound: true
+      env: {}
+      image: pilot
+      ingress:
+        ingressClass: istio
+        ingressControllerMode: STRICT
+        ingressService: istio-ilbgateway
+      keepaliveMaxServerConnectionAge: 30m
+      meshNetworks:
+        networks: {}
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      policy:
+        enabled: false
+      replicaCount: 1
+      tolerations: []
+      traceSampling: 1
+    prometheus:
+      contextPath: /prometheus
+      hub: docker.io/prom
+      ingress:
+        enabled: false
+        hosts:
+        - prometheus.local
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      provisionPrometheusCert: true
+      retention: 6h
+      scrapeInterval: 15s
+      security:
+        enabled: true
+      tag: v2.15.1
+      tolerations: []
+    security:
+      dnsCerts:
+        istio-pilot-service-account.istio-control: istio-pilot.istio-control
+      enableNamespacesByDefault: true
+      image: citadel
+      selfSigned: false
+    sidecarInjectorWebhook:
+      enableNamespacesByDefault: false
+      image: sidecar_injector
+      injectLabel: istio-injection
+      objectSelector:
+        autoInject: true
+        enabled: false
+      rewriteAppHTTPProbe: false
+      selfSigned: false
+    telemetry:
+      enabled: true
+      v1:
+        enabled: false
+      v2:
+        enabled: true
+        prometheus:
+          enabled: true
+        stackdriver:
+          configOverride: {}
+          enabled: true
+          logging: true
+          monitoring: true
+          topology: true
+    tracing:
+      ingress:
+        enabled: false
+      jaeger:
+        accessMode: ReadWriteMany
+        hub: docker.io/jaegertracing
+        memory:
+          max_traces: 50000
+        persist: false
+        spanStorageType: badger
+        storageClassName: ""
+        tag: "1.16"
+      nodeSelector: {}
+      opencensus:
+        exporters:
+          stackdriver:
+            enable_tracing: true
+        hub: docker.io/omnition
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        tag: 0.1.9
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      provider: jaeger
+      service:
+        annotations: {}
+        externalPort: 9411
+        name: http-query
+        type: ClusterIP
+      zipkin:
+        hub: docker.io/openzipkin
+        javaOptsHeap: 700
+        maxSpans: 500000
+        node:
+          cpus: 2
+        probeStartupDelay: 200
+        queryPort: 9411
+        resources:
+          limits:
+            cpu: 300m
+            memory: 900Mi
+          requests:
+            cpu: 150m
+            memory: 900Mi
+        tag: 2.14.2
+    version: ""
+

--- a/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-shared-controlplane.yaml
+++ b/infrastructure/ops/prod/k8s_repo/config/istio-controlplane/istio-shared-controlplane.yaml
@@ -1,96 +1,17 @@
-# Copyright 2019 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
-metadata:
-  namespace: istio-operator
-  name: shared-istiocontrolplane
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
 spec:
-  # Docs: https://istio.io/docs/reference/config/istio.operator.v1alpha12.pb/
-  autoInjection:
-    components:
-      injector:
-        enabled: true
-    enabled: true
-  cni:
-    components:
-      namespace: kube-system
-      cni:
-        enabled: true
-    enabled: true
-  configManagement:
-    components:
-      galley:
-        enabled: false
-    enabled: false
-  coreDNS:
-    components:
-      coreDNS:
-        enabled: true
-    enabled: true
-  gateways:
-    components:
-      egressGateway:
-        enabled: false
-      ingressGateway:
-        enabled: false
-    enabled: false
-  policy:
-    components:
-      policy:
-        enabled: false
-    enabled: false
-  security:
-    components:
-      certManager:
-        enabled: false
-      citadel:
-        enabled: true
-      nodeAgent:
-        enabled: false
-    enabled: true
-  telemetry:
-    components:
-      telemetry:
-        enabled: false
-    enabled: false
-  trafficManagement:
-    components:
-      pilot:
-        enabled: false
-    enabled: false
+  components:
+    cni:
+      enabled: true
   values:
     global:
-      controlPlaneSecurityEnabled: false
-      remotePilotCreateSvcEndpoint: true
-      remotePilotAddress: PILOT_ILB_IP
-      remotePolicyAddress: POLICY_ILB_IP
-      remoteTelemetryAddress: TELEMETRY_ILB_IP
-      enableTracing: false
-      istioRemote: true
+      multiCluster:
+        clusterName: CLUSTER_NAME
       network: ""
-    prometheus:
-      enabled: false
-    security:
-      createMeshPolicy: false
-      selfSigned: false
+      remotePilotAddress: PILOT_ILB_IP
     cni:
-      cniBinDir: /home/kubernetes/bin
       excludeNamespaces:
-        - istio-system
-        - kube-system
-  unvalidatedValues:
-    cni:
+       - istio-system
+       - kube-system
       logLevel: info

--- a/k8s_manifests/prod/app/deployments/app-ad-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-ad-service.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.0
         ports:
         - containerPort: 9555
         env:

--- a/k8s_manifests/prod/app/deployments/app-cart-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-cart-service.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: meganokeefe/cartservice:jan28fix
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.0
         ports:
         - containerPort: 7070
         env:

--- a/k8s_manifests/prod/app/deployments/app-checkout-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-checkout-service.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccount: checkout
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.1.3
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.0
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/k8s_manifests/prod/app/deployments/app-currency-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-currency-service.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.0
         ports:
         - name: grpc
           containerPort: 7000

--- a/k8s_manifests/prod/app/deployments/app-email-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-email-service.yaml
@@ -30,14 +30,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.0
         ports:
         - containerPort: 8080
         env:
         - name: PORT
           value: "8080"
-        - name: ENABLE_PROFILER
-          value: "0"
+        - name: DISABLE_PROFILER
+          value: "1"
         readinessProbe:
           periodSeconds: 5
           exec:

--- a/k8s_manifests/prod/app/deployments/app-frontend.yaml
+++ b/k8s_manifests/prod/app/deployments/app-frontend.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccount: frontend
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.1.3
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.0
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/k8s_manifests/prod/app/deployments/app-loadgenerator.yaml
+++ b/k8s_manifests/prod/app/deployments/app-loadgenerator.yaml
@@ -32,7 +32,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.2.0
         env:
         - name: FRONTEND_ADDR
           value: "frontend.frontend:80"

--- a/k8s_manifests/prod/app/deployments/app-payment-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-payment-service.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.0
         ports:
         - containerPort: 50051
         env:

--- a/k8s_manifests/prod/app/deployments/app-product-catalog-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-product-catalog-service.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.0
         ports:
         - containerPort: 3550
         readinessProbe:

--- a/k8s_manifests/prod/app/deployments/app-recommendation-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-recommendation-service.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.0
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -46,8 +46,8 @@ spec:
           value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice.product-catalog.svc.cluster.local:3550"
-        - name: ENABLE_PROFILER
-          value: "0"
+        - name: DISABLE_PROFILER
+          value: "1"
         resources:
           requests:
             cpu: 100m

--- a/k8s_manifests/prod/app/deployments/app-shipping-service.yaml
+++ b/k8s_manifests/prod/app/deployments/app-shipping-service.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccount: shipping
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.1.3
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.0
         ports:
         - containerPort: 50051
         env:

--- a/scripts/setup-gke-vars-kubeconfig.sh
+++ b/scripts/setup-gke-vars-kubeconfig.sh
@@ -16,7 +16,7 @@
 
 # TASK 2: Setting up Istio
 
-# Setting up GKE cluster names, regions, zones and contexts and add them to vars.sh 
+# Setting up GKE cluster names, regions, zones and contexts and add them to vars.sh
 
 # Font colors
 export CYAN='\033[1;36m'
@@ -26,7 +26,7 @@ export NC='\033[0m' # No Color
 # Export a SCRIPT_DIR var and make all links relative to SCRIPT_DIR
 export SCRIPT_DIR=$(dirname $(readlink -f $0 2>/dev/null) 2>/dev/null || echo "${PWD}/$(dirname $0)")
 
-# Create a log file and send stdout and stderr to console and log file 
+# Create a log file and send stdout and stderr to console and log file
 mkdir -p ${SCRIPT_DIR}/../logs
 export LOG_FILE=${SCRIPT_DIR}/../logs/setup-gke-vars-$(date +%s).log
 touch ${LOG_FILE}
@@ -35,13 +35,13 @@ exec &> >(tee -i ${LOG_FILE})
 
 
 # Add GKE vars to vars.sh and re-source vars
-echo -e "\n${CYAN}Adding GKE cluster names, regions, zones and contexts to vars.sh...${NC}" 
+echo -e "\n${CYAN}Adding GKE cluster names, regions, zones and contexts to vars.sh...${NC}"
 
 export VARS_FILE=${SCRIPT_DIR}/../vars/vars.sh
 source ${VARS_FILE}
 
 # Create GKE vars
-echo -e "export ISTIO_VERSION=1.4.3" | tee -a ${VARS_FILE}
+echo -e "export ISTIO_VERSION=1.5.4" | tee -a ${VARS_FILE}
 echo -e "export OPS_GKE_1_CLUSTER=gke-asm-1-r1-prod" | tee -a ${VARS_FILE}
 echo -e "export OPS_GKE_2_CLUSTER=gke-asm-2-r2-prod" | tee -a ${VARS_FILE}
 echo -e "export DEV1_GKE_1_CLUSTER=gke-1-apps-r1a-prod" | tee -a ${VARS_FILE}


### PR DESCRIPTION
#### [x] replace the dual ctrl profiles 
- enable CNI
- enable egressgateway 
- self signed set to false 
- Pilot (istiod) exposed via ILB - line 633 - with a custom IP - set in build_repo
- add cluster names via sed in build_repo.sh 
- disable galley (now part of istiod) 
- coredns enabled 
- mesh expansion enabled
- auto mtls enabled / but permissive 
- v1 policy (mixer) disabled entirely
- v1 telemetry (mixer) disabled - v2 enabled with all stackdriver toggles on (plus prometheus / grafana / kiali) 
- no citadel (part of istiod) 

#### [x] replace the shared ctrl profiles 
- enable CNI 
- dev1/2 call home to ops1's istiod ILB IP  - set in build_repo
- dev 3/4 call home to ops2's istiod ILB IP - set in build_repo
- add cluster names via sed in build_repo.sh

#### [x] upgrade hipstershop manifests

#### [ ] update stackdriver lab and fast track script (remove stackdriver adapter.) 

#### [ ] update mTLS lab and fast track script (Policy --> PeerAuthentication CRD) 

#### [ ] test workshop E2E to ensure no other changes are needed 